### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/gas_station_spain/sensor.py
+++ b/custom_components/gas_station_spain/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 )
 
 from homeassistant.components.sensor import (
-    SensorEntityDescription, SensorEntity, STATE_CLASS_MEASUREMENT
+    SensorEntityDescription, SensorEntity, SensorStateClass.MEASUREMENT
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -88,7 +88,7 @@ class GasStationSensor(CoordinatorEntity, SensorEntity):
             key=name,
             icon="mdi:gas-station",
             native_unit_of_measurement=CURRENCY_EURO,
-            state_class=STATE_CLASS_MEASUREMENT
+            state_class=SensorStateClass.MEASUREMENT
         )
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
STATE_CLASS_MEASUREMENT was used from gas_station_spain, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.MEASUREMENT instead.