### PR TITLE
Update manifest

### DIFF
--- a/custom_components/gas_station_spain/manifest.json
+++ b/custom_components/gas_station_spain/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MiguelAngelLV/gas_station_spain/issues",
   "requirements": [],
-  "version": "0.8.0"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
**Se ha actualizado la versión del manifest.json para que concuerde con la release**

### Problema que resuelve

Debido a que el _manifest.json_ de la integración no se actualizaba HACS era incapaz de saber que hay una actualización disponible y por tanto no intentaba actualizarla. Con la nueva versión de HA que deprecaba una API antigua me he dado cuenta que la versión en la que se corrige yo no la tenía instalada ya que no he recibido actualizaciones desde el momento que la instalé. 

Actualizando el _manifest.json_, cuando HACS comprueba si hay actualizaciones, salta una notificación dentro de HA para que se pueda actualizar.